### PR TITLE
Refactor: Replace player foreign key

### DIFF
--- a/etl/__init__.py
+++ b/etl/__init__.py
@@ -1,1 +1,2 @@
 from .pipeline import run_pipeline
+from .migrations import link_players_to_teams

--- a/etl/extract.py
+++ b/etl/extract.py
@@ -5,54 +5,8 @@ import pandas as pd
 
 
 def extract_data():
-    extract_sports_reference_data()
     extract_wiki_data()
-
-
-def extract_sports_reference_data():
-    team_roster_info = []
-    team_stats_info = []
-
-    url = 'https://www.sports-reference.com/cbb/postseason/men/2025-ncaa.html'
-    response = requests.get(url)
-    soup = BeautifulSoup(response.text, 'lxml')
-
-    divs = soup.find_all('div', {'class': 'team16'})
-    divs = ''.join(str(div) for div in divs)
-    div_soup = BeautifulSoup(divs, 'lxml')
-
-    tags = div_soup.find_all('a')
-
-    team_links_to_names = {tag.get('href'): tag.text.strip() for tag in tags if '/cbb/schools/' in tag.get('href')}
-    team_links_to_names = {f"https://www.sports-reference.com/{link}": name for link, name in team_links_to_names.items()}
-
-    team_links_to_names = dict(sorted(team_links_to_names.items(), key=lambda item: item[1]))
-
-    for team_url, team_name in team_links_to_names.items():
-        html = requests.get(team_url).text
-        soup = BeautifulSoup(html, 'lxml')
-
-        tables = soup.find_all('table')
-
-        roster_table = tables[0]
-        stats_table = tables[5]
-
-        roster_info = pd.read_html(str(roster_table))[0]
-        roster_info["Team"] = team_name
-        team_roster_info.append(roster_info)
-
-        stats_info = pd.read_html(str(stats_table))[0]
-        stats_info["Team"] = team_name
-        team_stats_info.append(stats_info)
-
-        print(f"Finished processing {team_name}!")
-        sleep(5)
-
-    roster_df = pd.concat(team_roster_info, ignore_index=True)
-    roster_df.to_csv('data/team_rosters.csv', index=False)
-
-    stats_df = pd.concat(team_stats_info, ignore_index=True)
-    stats_df.to_csv('data/team_stats.csv', index=False)
+    extract_sports_reference_data()
 
 
 def extract_wiki_data():
@@ -110,3 +64,49 @@ def extract_wiki_data():
 
     teams_df = pd.DataFrame(teams_data, columns=file_headers)
     teams_df.to_csv('data/teams_data.csv', index=False)
+
+
+def extract_sports_reference_data():
+    team_roster_info = []
+    team_stats_info = []
+
+    url = 'https://www.sports-reference.com/cbb/postseason/men/2025-ncaa.html'
+    response = requests.get(url)
+    soup = BeautifulSoup(response.text, 'lxml')
+
+    divs = soup.find_all('div', {'class': 'team16'})
+    divs = ''.join(str(div) for div in divs)
+    div_soup = BeautifulSoup(divs, 'lxml')
+
+    tags = div_soup.find_all('a')
+
+    team_links_to_names = {tag.get('href'): tag.text.strip() for tag in tags if '/cbb/schools/' in tag.get('href')}
+    team_links_to_names = {f"https://www.sports-reference.com/{link}": name for link, name in team_links_to_names.items()}
+
+    team_links_to_names = dict(sorted(team_links_to_names.items(), key=lambda item: item[1]))
+
+    for team_url, team_name in team_links_to_names.items():
+        html = requests.get(team_url).text
+        soup = BeautifulSoup(html, 'lxml')
+
+        tables = soup.find_all('table')
+
+        roster_table = tables[0]
+        stats_table = tables[5]
+
+        roster_info = pd.read_html(str(roster_table))[0]
+        roster_info["Team"] = team_name
+        team_roster_info.append(roster_info)
+
+        stats_info = pd.read_html(str(stats_table))[0]
+        stats_info["Team"] = team_name
+        team_stats_info.append(stats_info)
+
+        print(f"Finished processing {team_name}!")
+        sleep(5)
+
+    roster_df = pd.concat(team_roster_info, ignore_index=True)
+    roster_df.to_csv('data/team_rosters.csv', index=False)
+
+    stats_df = pd.concat(team_stats_info, ignore_index=True)
+    stats_df.to_csv('data/team_stats.csv', index=False)

--- a/etl/load.py
+++ b/etl/load.py
@@ -1,5 +1,3 @@
-
-
 def load_data(conn):
     create_tables(conn)
     load_teams(conn)
@@ -11,7 +9,7 @@ def create_tables(conn):
     cursor = conn.cursor()
 
     cursor.execute("""  CREATE TABLE IF NOT EXISTS teams (
-                        team_id             INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                        id                  INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
                         name                VARCHAR(50) NOT NULL UNIQUE,
                         record              VARCHAR(50) NOT NULL,
                         wins                INT NOT NULL,
@@ -26,48 +24,48 @@ def create_tables(conn):
                     ); """)
     
     cursor.execute("""  CREATE TABLE IF NOT EXISTS players (
-                        player_id       INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-                        name            VARCHAR(50) NOT NULL,
-                        jersey_number   INT NOT NULL,
-                        class           VARCHAR(2) NULL,
-                        position        VARCHAR(1) NOT NULL,
-                        height          VARCHAR(10) NULL,
-                        weight          REAL NULL,
-                        hometown        VARCHAR(150) NULL,
-                        high_school     VARCHAR(150) NULL,
-                        team            VARCHAR(50),
+                        id                  INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                        name                VARCHAR(50) NOT NULL,
+                        jersey_number       INT NOT NULL,
+                        class               VARCHAR(2) NULL,
+                        position            VARCHAR(1) NOT NULL,
+                        height              VARCHAR(10) NULL,
+                        weight              REAL NULL,
+                        hometown            VARCHAR(150) NULL,
+                        high_school         VARCHAR(150) NULL,
+                        team                VARCHAR(50),
 
                         CONSTRAINT fk_team FOREIGN KEY (team) REFERENCES teams(name) ON DELETE CASCADE
                     ); """)
 
     cursor.execute("""  CREATE TABLE IF NOT EXISTS player_stats (
-                        stats_id INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-                        player_id INT NOT NULL,
-                        games_played INT,
-                        games_started INT,
-                        minutes_played NUMERIC(3, 1),
-                        field_goals NUMERIC(3, 1),
-                        field_goals_attempted NUMERIC(3, 1),
-                        field_goal_percentage NUMERIC(4, 3) DEFAULT 0,
-                        three_points NUMERIC(3, 1),
-                        three_points_attempted NUMERIC(3, 1),
-                        three_point_percentage NUMERIC(4, 3) DEFAULT 0,
-                        two_points NUMERIC(3, 1),
-                        two_points_attempted NUMERIC(3, 1),
-                        two_point_percentage NUMERIC(4, 3) DEFAULT 0,
+                        id                              INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                        player_id                       INT NOT NULL,
+                        games_played                    INT,
+                        games_started                   INT,
+                        minutes_played                  NUMERIC(3, 1),
+                        field_goals                     NUMERIC(3, 1),
+                        field_goals_attempted           NUMERIC(3, 1),
+                        field_goal_percentage           NUMERIC(4, 3) DEFAULT 0,
+                        three_points                    NUMERIC(3, 1),
+                        three_points_attempted          NUMERIC(3, 1),
+                        three_point_percentage          NUMERIC(4, 3) DEFAULT 0,
+                        two_points                      NUMERIC(3, 1),
+                        two_points_attempted            NUMERIC(3, 1),
+                        two_point_percentage            NUMERIC(4, 3) DEFAULT 0,
                         effective_field_goal_percentage NUMERIC (4, 3) DEFAULT 0,
-                        free_throws NUMERIC(3, 1),
-                        free_throws_attempted NUMERIC(3, 1),
-                        free_throws_percentage NUMERIC(4, 3) DEFAULT 0,
-                        offensive_rebounds NUMERIC(3, 1),
-                        defensive_rebounds NUMERIC(3, 1),
-                        total_rebounds NUMERIC(3, 1),
-                        assists NUMERIC(3, 1),
-                        steals NUMERIC(3, 1),
-                        blocks NUMERIC(3, 1),
-                        turnovers NUMERIC(3, 1),
-                        personal_fouls NUMERIC(3, 1),
-                        points_per_game NUMERIC(3, 1),
+                        free_throws                     NUMERIC(3, 1),
+                        free_throws_attempted           NUMERIC(3, 1),
+                        free_throws_percentage          NUMERIC(4, 3) DEFAULT 0,
+                        offensive_rebounds              NUMERIC(3, 1),
+                        defensive_rebounds              NUMERIC(3, 1),
+                        total_rebounds                  NUMERIC(3, 1),
+                        assists                         NUMERIC(3, 1),
+                        steals                          NUMERIC(3, 1),
+                        blocks                          NUMERIC(3, 1),
+                        turnovers                       NUMERIC(3, 1),
+                        personal_fouls                  NUMERIC(3, 1),
+                        points_per_game                 NUMERIC(3, 1),
                    
                         CONSTRAINT fk_player FOREIGN KEY (player_id) REFERENCES players(player_id) ON DELETE CASCADE
                     ); """)    

--- a/etl/migrations.py
+++ b/etl/migrations.py
@@ -1,0 +1,29 @@
+def link_players_to_teams(conn):
+    cursor = conn.cursor()
+
+    cursor.execute("""  ALTER TABLE players
+                        ADD COLUMN IF NOT EXISTS
+                        team_id INT;
+                   """)
+    
+    cursor.execute("""  UPDATE players
+                        SET team_id = teams.id
+                        FROM teams
+                        WHERE players.team = teams.name;
+                   """)
+    
+    cursor.execute("""  ALTER TABLE players
+                        ADD CONSTRAINT fk_team_id
+                        FOREIGN KEY (team_id) REFERENCES teams(id);
+                   """)
+    
+    cursor.execute("""  ALTER TABLE players
+                        DROP COLUMN team;
+                   """)
+    
+    cursor.execute("""  ALTER TABLE players
+                        DROP CONSTRAINT IF EXISTS fk_team;
+                   """)
+    
+    conn.commit()
+    cursor.close()

--- a/etl/transform.py
+++ b/etl/transform.py
@@ -3,24 +3,39 @@ import pandas as pd
 
 
 def transform_data():
-    transform_sports_reference_data()
     transform_wiki_data()
+    transform_sports_reference_data()
 
 
 def clean_column(name):
     return re.sub(r'\s*\(.*?\).*', '', name)
 
 
+def transform_wiki_data():
+    wiki_data = pd.read_csv('data/teams_data.csv', encoding='utf-8')
+    wiki_data.sort_values(by='Team', inplace=True)
+    wiki_data.rename(columns={'Head coach': 'Coach'}, inplace=True)
+
+    wiki_data['Coach'] = wiki_data['Coach'].apply(clean_column)
+    
+    wiki_data['Conference'] = wiki_data['Conference'].apply(clean_column)
+    wiki_data['Conference'] = wiki_data['Conference'].str.replace(r'\bConference\b', '', regex=True).str.strip()
+
+    wiki_data['Nickname'] = wiki_data['Nickname'].apply(clean_column)
+
+    wiki_data['Record'] = wiki_data['Record'].str.replace('\u2013', '-').str.strip()
+    wiki_data[['Wins', 'Losses', 'Conference Wins', 'Conference Losses']] = wiki_data['Record'].str.extract(r'(\d+)-(\d+)\s+\((\d+)-(\d+)[^)]*\)').astype(int)
+    wiki_data = wiki_data[[
+        "Team", "Record", "Wins", "Losses", "Conference Wins", "Conference Losses",
+        "University", "Coach", "Conference", "Location", "Nickname"
+    ]]
+    
+    wiki_data.to_csv('data/cleaned_teams_data.csv', index=False)
+
+
 def transform_sports_reference_data():
     roster_data = pd.read_csv('data/team_rosters.csv', encoding='utf-8')
     stats_data = pd.read_csv('data/team_stats.csv', encoding='utf-8')
-
-    stats_data = stats_data[stats_data['Player'] != 'Team Totals']
-    stats_data.drop(axis=1, columns=['Rk', 'Pos', 'Awards'], inplace=True)
-    stats_data.loc[stats_data['Team'].str.contains('McNeese State', case=False, na=False), 'Team'] = 'McNeese'
-    stats_data.loc[stats_data['Team'].str.contains('UNC', case=False, na=False), 'Team'] = 'North Carolina'
-    stats_data['Team'] = stats_data['Team'].str.replace('-', ' ')
-    stats_data['Team'] = stats_data['Team'].apply(clean_column)
 
     roster_data = roster_data[~roster_data['Summary'].isnull()]
     roster_data.drop(axis=1, columns=['RSCI Top 100', 'Summary'], inplace=True)
@@ -29,6 +44,12 @@ def transform_sports_reference_data():
     roster_data['Team'] = roster_data['Team'].str.replace('-', ' ')
     roster_data['Team'] = roster_data['Team'].apply(clean_column)
 
+    stats_data = stats_data[stats_data['Player'] != 'Team Totals']
+    stats_data.drop(axis=1, columns=['Rk', 'Pos', 'Awards'], inplace=True)
+    stats_data.loc[stats_data['Team'].str.contains('McNeese State', case=False, na=False), 'Team'] = 'McNeese'
+    stats_data.loc[stats_data['Team'].str.contains('UNC', case=False, na=False), 'Team'] = 'North Carolina'
+    stats_data['Team'] = stats_data['Team'].str.replace('-', ' ')
+    stats_data['Team'] = stats_data['Team'].apply(clean_column)
 
     stats_name_map = {}
     for _, row in stats_data.iterrows():
@@ -56,9 +77,9 @@ def transform_sports_reference_data():
     roster_data['Player'] = roster_data['Player'].apply(fix_encoding)
     roster_data['High School'] = roster_data['High School'].apply(fix_encoding)
     roster_data['Hometown'] = roster_data['Hometown'].apply(fix_encoding)
-
     roster_data.sort_values(by=['Team', 'Player'], inplace=True)
     
+
     stats_data['Player'] = stats_data['Player'].apply(fix_encoding)
     stats_data.sort_values(by=['Team', 'Player'], inplace=True)
 
@@ -67,27 +88,8 @@ def transform_sports_reference_data():
     stats_data.index += 1
     stats_data.drop(columns=['Player', 'Team'], inplace=True)
 
-    roster_data.to_csv('data/cleaned_roster_data.csv', index=False)
-    stats_data.to_csv('data/cleaned_stats_data.csv')
+    # roster_data.to_csv('data/cleaned_roster_data.csv', index=False)
+    # stats_data.to_csv('data/cleaned_stats_data.csv')
 
-
-def transform_wiki_data():
-    wiki_data = pd.read_csv('data/teams_data.csv', encoding='utf-8')
-    wiki_data.sort_values(by='Team', inplace=True)
-    wiki_data.rename(columns={'Head coach': 'Coach'}, inplace=True)
-
-    wiki_data['Coach'] = wiki_data['Coach'].apply(clean_column)
-    
-    wiki_data['Conference'] = wiki_data['Conference'].apply(clean_column)
-    wiki_data['Conference'] = wiki_data['Conference'].str.replace(r'\bConference\b', '',regex=True).str.strip()
-
-    wiki_data['Nickname'] = wiki_data['Nickname'].apply(clean_column)
-
-    wiki_data['Record'] = wiki_data['Record'].str.replace('\u2013', '-').str.strip()
-    wiki_data[['Wins', 'Losses', 'Conference Wins', 'Conference Losses']] = wiki_data['Record'].str.extract(r'(\d+)-(\d+)\s+\((\d+)-(\d+)[^)]*\)').astype(int)
-    wiki_data = wiki_data[[
-        "Team", "Record", "Wins", "Losses", "Conference Wins", "Conference Losses",
-        "University", "Coach", "Conference", "Location", "Nickname"
-    ]]
-    
-    wiki_data.to_csv('data/cleaned_teams_data.csv', index=False)
+    roster_data.to_csv('data/test_roster_data.csv', index=False)
+    stats_data.to_csv('data/test_stats_data.csv')

--- a/main.py
+++ b/main.py
@@ -1,8 +1,7 @@
 import os
 from dotenv import load_dotenv
 import psycopg2
-from etl import run_pipeline
-from etl.migrations import link_players_to_teams
+from etl import run_pipeline, link_players_to_teams
 
 def main():
     load_dotenv()

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ import os
 from dotenv import load_dotenv
 import psycopg2
 from etl import run_pipeline
-
+from etl.migrations import link_players_to_teams
 
 def main():
     load_dotenv()
@@ -21,7 +21,11 @@ def main():
         port=port
     )
 
+    # Extract, Transform, Load
     run_pipeline(conn)
+
+    # Foreign Key Fix
+    link_players_to_teams(conn)
 
     conn.close()
 


### PR DESCRIPTION
# Database Table Refactoring

## Problem & Motivation
The Players table contained a non-integer foreign key named "team".  This column contains a string of the name of the team the player belongs to.  While this makes it easy for developers to see the name of the team associated with the player, non-integer foreign keys introduce a couple problems.  Strings typically consume more storage than integer data types, which can impact query performance. Managing non-integer foreign keys can become complicated when dealing with data entry and variations in string formatting, like case sensitivity and leading/trailing whitespace, for example.

## Solution
These changes include a migration that alters the players table by replacing the string foreign key with an integer foreign key using psycopg2 to run multiple SQL queries in succession.  The new foreign key in the players table now references the team's primary key, id.
